### PR TITLE
	Make A/B test names case-sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Before starting this, you'll need to
 
 - get your cookie listed on [/help/cookies](https://www.gov.uk/help/cookies)
 - configure the CDN [like we did for the Education Navigation test](https://github.com/alphagov/govuk-cdn-config/pull/17).
+The cookie and header name in the CDN config must match the test name parameter
+that you pass to the Gem. The cookie name is case-sensitive.
 - configure Google Analytics (guidelines to follow)
 
 To enable testing in the app, your Rails app needs:

--- a/lib/govuk_ab_testing/ab_test.rb
+++ b/lib/govuk_ab_testing/ab_test.rb
@@ -21,9 +21,8 @@ module GovukAbTesting
       "GOVUK-ABTest-#{meta_tag_name}"
     end
 
-    # `example` -> `Example`
     def meta_tag_name
-      ab_test_name.capitalize
+      ab_test_name
     end
   end
 end

--- a/lib/govuk_ab_testing/requested_variant.rb
+++ b/lib/govuk_ab_testing/requested_variant.rb
@@ -2,7 +2,7 @@ module GovukAbTesting
   class RequestedVariant
     attr_reader :ab_test, :request
 
-    # @param ab_test_name [AbTest] Lowercase A/B test name, like `example`
+    # @param ab_test [AbTest] the A/B test being performed
     # @param request [ApplicationController::Request] the `request` in the
     # controller.
     def initialize(ab_test, request)

--- a/spec/requested_variant_spec.rb
+++ b/spec/requested_variant_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 RSpec.describe GovukAbTesting::RequestedVariant do
   def ab_test
-    GovukAbTesting::AbTest.new("education")
+    GovukAbTesting::AbTest.new("EducationNav")
   end
 
   describe '#variant_name' do
     it "returns the variant" do
-      activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATION' => 'A'})
+      activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATIONNAV' => 'A'})
 
       requested_variant = ab_test.requested_variant(activesupport_request)
 
@@ -17,7 +17,7 @@ RSpec.describe GovukAbTesting::RequestedVariant do
 
   describe '#variant_a?' do
     it "returns the variant" do
-      activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATION' => 'A'})
+      activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATIONNAV' => 'A'})
 
       requested_variant = ab_test.requested_variant(activesupport_request)
 
@@ -28,7 +28,7 @@ RSpec.describe GovukAbTesting::RequestedVariant do
 
   describe '#variant_b?' do
     it "returns the variant" do
-      activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATION' => 'B'})
+      activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATIONNAV' => 'B'})
 
       requested_variant = ab_test.requested_variant(activesupport_request)
 
@@ -39,27 +39,27 @@ RSpec.describe GovukAbTesting::RequestedVariant do
 
   describe '#analytics_meta_tag' do
     it "returns the tag" do
-      activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATION' => 'A'})
+      activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATIONNAV' => 'A'})
 
       requested_variant = ab_test.requested_variant(activesupport_request)
 
-      expect(requested_variant.analytics_meta_tag).to eql("<meta name=\"govuk:ab-test\" content=\"Education:A\">")
+      expect(requested_variant.analytics_meta_tag).to eql("<meta name=\"govuk:ab-test\" content=\"EducationNav:A\">")
     end
   end
 
   describe '#configure_response' do
     it "sets the correct header" do
-      activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATION' => 'A'})
+      activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATIONNAV' => 'A'})
       requested_variant = ab_test.requested_variant(activesupport_request)
       response = double(headers: {})
 
       requested_variant.configure_response(response)
 
-      expect(response.headers['Vary']).to eql('GOVUK-ABTest-Education')
+      expect(response.headers['Vary']).to eql('GOVUK-ABTest-EducationNav')
     end
 
     it "crashes if the Vary header is already set" do
-      activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATION' => 'A'})
+      activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATIONNAV' => 'A'})
       requested_variant = ab_test.requested_variant(activesupport_request)
       response = double(headers: { 'Vary' => 'Some vary header set by someone else'})
 


### PR DESCRIPTION
Remove automatic capitalization of test names, so the test name you specify matches the cookie name and meta tag exactly.

- Removes ambiguity about the capitalization, which makes it easier to configure the CDN cookie config so that it matches the test name.
- Gives users more control over the test name, which needs to be readable in the Google Analytics results and in the Chrome extension.

I'm just a bit worried the capitalization would trip someone up when they're configuring the cookie in the CDN.