### PR TITLE
CI and gem publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,44 @@
+#!/usr/bin/env groovy
+
+node {
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+  try {
+    stage('Checkout') {
+      checkout scm
+    }
+
+    stage('Clean') {
+      govuk.cleanupGit()
+      govuk.mergeMasterBranch()
+    }
+
+    stage('Bundle') {
+      echo 'Bundling'
+      sh("bundle install --path ${JENKINS_HOME}/bundles/${JOB_NAME}")
+    }
+
+    stage('Linter') {
+      govuk.rubyLinter()
+    }
+
+    stage('Tests') {
+      govuk.setEnvar('RAILS_ENV', 'test')
+      govuk.runTests()
+    }
+
+    if(env.BRANCH_NAME == "master") {
+      stage('Publish Gem') {
+        govuk.runRakeTask("publish_gem --trace")
+      }
+    }
+
+  } catch (e) {
+    currentBuild.result = 'FAILED'
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+}

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,13 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "gem_publisher"
 
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+desc "Publish gem to RubyGems"
+task :publish_gem do |_t|
+  published_gem = GemPublisher.publish_if_updated("govuk_ab_testing.gemspec", :rubygems)
+  puts "Published #{published_gem}" if published_gem
+end

--- a/govuk_ab_testing.gemspec
+++ b/govuk_ab_testing.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "yard", "~> 0.8"
+  spec.add_development_dependency "gem_publisher", "~> 1.5.0"
 end


### PR DESCRIPTION
This Pull Request is part of the work to publish the [AB Testing Gem](https://github.com/alphagov/govuk_ab_testing) to [RubyGems.org](http://rubygems.org).

This adds a `Jenkinsfile` for building on Jenkins 2, as well as a rake task for publishing the gem. This is a direct readacross of `govuk_navigation_helpers`. The migration to Jenkins 2 is here: https://github.com/alphagov/govuk_navigation_helpers/pull/20

Trello: https://trello.com/c/tclzOZ7Z/382-release-govuk-ab-testing-to-rubygems