### PR TITLE
Configure Google Analytics dimension for A/B test

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetRubyVersion: 2.3

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ that you pass to the Gem. The cookie name is case-sensitive.
 To enable testing in the app, your Rails app needs:
 
 1. Some piece of logic to be A/B tested
-2. A HTML meta tag that will be used to measure the results
+2. A HTML meta tag that will be used to measure the results, and which specifies
+the dimension to use in Google Analytics
 3. A response HTTP header that tells Fastly you're doing an A/B test
 
 Let's say you have this controller:
@@ -38,7 +39,7 @@ Let's say you have this controller:
 # app/controllers/party_controller.rb
 class PartyController < ApplicationController
   def show
-    ab_test = GovukAbTesting::AbTest.new("your_ab_test_name")
+    ab_test = GovukAbTesting::AbTest.new("your_ab_test_name", dimension: 300)
     @requested_variant = ab_test.requested_variant(request)
     @requested_variant.configure_response(response)
 

--- a/lib/govuk_ab_testing/ab_test.rb
+++ b/lib/govuk_ab_testing/ab_test.rb
@@ -2,14 +2,18 @@ module GovukAbTesting
   class AbTest
     attr_reader :ab_test_name
 
-    def initialize(ab_test_name)
+    # @param request [String] the name of the A/B test
+    # @param dimension [Integer] the dimension registered with Google Analytics
+    # for this specific A/B test
+    def initialize(ab_test_name, dimension:)
       @ab_test_name = ab_test_name
+      @dimension = dimension
     end
 
     # @param request [ApplicationController::Request] the `request` in the
     # controller.
     def requested_variant(request)
-      RequestedVariant.new(self, request)
+      RequestedVariant.new(self, request, @dimension)
     end
 
     # Internal name of the header

--- a/lib/govuk_ab_testing/requested_variant.rb
+++ b/lib/govuk_ab_testing/requested_variant.rb
@@ -5,9 +5,12 @@ module GovukAbTesting
     # @param ab_test [AbTest] the A/B test being performed
     # @param request [ApplicationController::Request] the `request` in the
     # controller.
-    def initialize(ab_test, request)
+    # @param dimension [Integer] the dimension registered with Google Analytics
+    # for this specific A/B test
+    def initialize(ab_test, request, dimension)
       @ab_test = ab_test
       @request = request
+      @dimension = dimension
     end
 
     # Get the bucket this user is in
@@ -39,7 +42,9 @@ module GovukAbTesting
     #
     # @return [String]
     def analytics_meta_tag
-      '<meta name="govuk:ab-test" content="' + ab_test.meta_tag_name + ':' + variant_name + '">'
+      '<meta name="govuk:ab-test" ' +
+        'content="' + ab_test.meta_tag_name + ':' + variant_name + '" ' +
+        'data-analytics-dimension="' + @dimension.to_s + '">'
     end
   end
 end

--- a/spec/minitest_helpers_spec.rb
+++ b/spec/minitest_helpers_spec.rb
@@ -4,8 +4,13 @@ class AnExampleMiniTestCase < FakeMinitestControllerTestCase
   include GovukAbTesting::MinitestHelpers
 
   def test_name_of_a_test
-    with_variant(example: 'B') do
+    with_variant(example: 'B', dimension: 50) do
       # We're testing the behaviour of `with_variant` here.
+    end
+  end
+
+  def test_with_missing_dimension
+    with_variant(example: 'B') do
     end
   end
 end
@@ -13,5 +18,9 @@ end
 describe GovukAbTesting::MinitestHelpers do
   it "runs without errors" do
     AnExampleMiniTestCase.new.test_name_of_a_test
+  end
+
+  it "rejects test with missing dimension parameter" do
+    expect { AnExampleMiniTestCase.new.test_with_missing_dimension }.to raise_error(/dimension/)
   end
 end

--- a/spec/requested_variant_spec.rb
+++ b/spec/requested_variant_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe GovukAbTesting::RequestedVariant do
   def ab_test
-    GovukAbTesting::AbTest.new("EducationNav")
+    GovukAbTesting::AbTest.new("EducationNav", dimension: 500)
   end
 
   describe '#variant_name' do
@@ -38,12 +38,14 @@ RSpec.describe GovukAbTesting::RequestedVariant do
   end
 
   describe '#analytics_meta_tag' do
-    it "returns the tag" do
+    it "returns the tag with the analytics dimension" do
       activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATIONNAV' => 'A'})
 
-      requested_variant = ab_test.requested_variant(activesupport_request)
+      requested_variant = GovukAbTesting::AbTest.new("EducationNav", dimension: 207).
+        requested_variant(activesupport_request)
 
-      expect(requested_variant.analytics_meta_tag).to eql("<meta name=\"govuk:ab-test\" content=\"EducationNav:A\">")
+      expect(requested_variant.analytics_meta_tag).to eql(
+        "<meta name=\"govuk:ab-test\" content=\"EducationNav:A\" data-analytics-dimension=\"207\">")
     end
   end
 


### PR DESCRIPTION
Make the dimension a required parameter when configuring a test, because we expect every A/B test to report its results to Google Analytics.

Include the dimension in the `meta` tag, so that the GA JavaScript will report the user's variant using the correct GA dimension. This matches the format proposed in alphagov/static#890.

Trello: https://trello.com/c/g9OyC7Pn/310-tell-google-analytics-about-a-b-tests