### PR TITLE
Add missing govuk-lint dependency

### DIFF
--- a/govuk_ab_testing.gemspec
+++ b/govuk_ab_testing.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "govuk-lint", "~> 1.2.1"
   spec.add_development_dependency "yard", "~> 0.8"
   spec.add_development_dependency "gem_publisher", "~> 1.5.0"
 end


### PR DESCRIPTION
This fixes the Jenkins branch builds.

We didn't spot this when adding the Jenkinsfile because the master build skips the linting step.