### PR TITLE
Merge Vary HTTP headers

### DIFF
--- a/lib/govuk_ab_testing/minitest_helpers.rb
+++ b/lib/govuk_ab_testing/minitest_helpers.rb
@@ -10,7 +10,8 @@ module GovukAbTesting
 
       yield
 
-      assert_equal ab_test.response_header, response.headers['Vary'], "You probably forgot to use `configure_response`"
+      assert_match ab_test.response_header, response.headers['Vary'],
+        "You probably forgot to use `configure_response`"
 
       unless args[:assert_meta_tag] == false
         content = ab_test.meta_tag_name + ':' + requested_variant.variant_name

--- a/lib/govuk_ab_testing/requested_variant.rb
+++ b/lib/govuk_ab_testing/requested_variant.rb
@@ -34,8 +34,7 @@ module GovukAbTesting
     #
     # @param [ApplicationController::Response] the `response` in the controller
     def configure_response(response)
-      raise "We're trying to set the Vary header, but this would override the current header" if response.headers['Vary']
-      response.headers['Vary'] = ab_test.response_header
+      response.headers['Vary'] = [response.headers['Vary'], ab_test.response_header].compact.join(', ')
     end
 
     # HTML meta tag used to track the results of your experiment

--- a/spec/requested_variant_spec.rb
+++ b/spec/requested_variant_spec.rb
@@ -60,14 +60,14 @@ RSpec.describe GovukAbTesting::RequestedVariant do
       expect(response.headers['Vary']).to eql('GOVUK-ABTest-EducationNav')
     end
 
-    it "crashes if the Vary header is already set" do
+    it "appends if the Vary header is already set" do
       activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATIONNAV' => 'A'})
       requested_variant = ab_test.requested_variant(activesupport_request)
-      response = double(headers: { 'Vary' => 'Some vary header set by someone else'})
+      response = double(headers: { 'Vary' => 'GOVUK-OtherHeader'})
 
-      expect {
-        requested_variant.configure_response(response)
-      }.to raise_error(StandardError)
+      requested_variant.configure_response(response)
+
+      expect(response.headers['Vary']).to eql('GOVUK-OtherHeader, GOVUK-ABTest-EducationNav')
     end
   end
 end

--- a/spec/requested_variant_spec.rb
+++ b/spec/requested_variant_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe GovukAbTesting::RequestedVariant do
     it "appends if the Vary header is already set" do
       activesupport_request = double(headers: { 'HTTP_GOVUK_ABTEST_EDUCATIONNAV' => 'A'})
       requested_variant = ab_test.requested_variant(activesupport_request)
-      response = double(headers: { 'Vary' => 'GOVUK-OtherHeader'})
+      response = double(headers: { 'Vary' => 'GOVUK-OtherHeader' })
 
       requested_variant.configure_response(response)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,9 @@ class FakeMinitestControllerTestCase
   def assert_select(*)
   end
 
+  def assert_match(*)
+  end
+
   def response
     FakeRequestResponseObject.new
   end


### PR DESCRIPTION
As suggested in https://github.com/alphagov/govuk_ab_testing/pull/1#discussion_r99109109 we can merge the `Vary` headers if they exist.

