### PR TITLE
Improve test helper name

### DIFF
--- a/lib/govuk_ab_testing/minitest_helpers.rb
+++ b/lib/govuk_ab_testing/minitest_helpers.rb
@@ -26,7 +26,7 @@ module GovukAbTesting
       @request.headers[ab_test.request_header] = variant
     end
 
-    def assert_unaffected_by_ab_test
+    def assert_response_not_modified_for_ab_test
       assert_nil response.headers['Vary'],
         "`Vary` header is being added to a page which is outside of the A/B test"
 


### PR DESCRIPTION
Rename helper to make its purpose clearer to people who don't know the details of A/B testing.

Suggested in alphagov/collections#232.

This changes the API of the gem, but we're still pre-1.0 and I think my redirects PR is the only thing which relies on it.