### PR TITLE
Delete unnecessary CI step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,6 @@ node {
     }
 
     stage('Tests') {
-      govuk.setEnvar('RAILS_ENV', 'test')
       govuk.runTests()
     }
 


### PR DESCRIPTION
The gem doesn't depend on Rails, so there's no need to set a Rails environment variable when running the tests.