### PR TITLE
Include capybara helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ by the extension and analytics.
 
 #### Test helpers
 
+##### Minitest
+
 The most common usage of an A/B test is to serve two different variants of the
 same page. In this situation, you can test the controller using `with_variant`.
 It will configure the request and assert that the response is configured
@@ -120,6 +122,36 @@ class PartyControllerTest < ActionController::TestCase
   end
 end
 ```
+
+##### RSpec + Capybara
+
+It is also possible to use `with_variant` in RSpec tests that use Capybara. Here
+is an example of a spec file:
+
+```ruby
+# spec/features/ab_testing_spec.rb
+feature "Viewing a page with an A/B test" do
+  include GovukAbTesting::RspecCapybaraHelpers
+
+  scenario "viewing the B version of the page" do
+    with_variant your_ab_test_name: 'B' do
+      visit root_path
+
+      expect(page).to have_breadcrumbs
+      expect(page).to have_beta_label
+    end
+  end
+end
+```
+
+Please note that `with_variant` in `GovukAbTesting::RspecCapybaraHelpers`
+expects both `page` (Capybara session) and RSpec expectations to be available.
+
+As with the `minitest` version, you can also pass in the following options to
+`with_variant`:
+
+- `assert_meta_tag: false`
+- `dimension: <number>`
 
 ### Running the test suite
 

--- a/lib/govuk_ab_testing.rb
+++ b/lib/govuk_ab_testing.rb
@@ -2,6 +2,7 @@ require "govuk_ab_testing/version"
 require "govuk_ab_testing/requested_variant"
 require "govuk_ab_testing/ab_test"
 require "govuk_ab_testing/minitest_helpers"
+require "govuk_ab_testing/rspec_capybara_helpers"
 
 module GovukAbTesting
 end

--- a/lib/govuk_ab_testing/rspec_capybara_helpers.rb
+++ b/lib/govuk_ab_testing/rspec_capybara_helpers.rb
@@ -1,0 +1,33 @@
+module GovukAbTesting
+  module RspecCapybaraHelpers
+    def with_variant(args)
+      unless defined?(page)
+        raise "The variable 'page' is not defined, are you using capybara?"
+      end
+
+      ab_test_name, variant = args.first
+      dimension = args[:dimension]
+      ab_test =
+        GovukAbTesting::AbTest.new(ab_test_name.to_s, dimension: dimension)
+
+      page.driver.header(ab_test.response_header, variant)
+
+      yield
+
+      expect(ab_test.response_header).to eq(page.response_headers['Vary'])
+
+      unless args[:assert_meta_tag] == false
+        content = [ab_test.meta_tag_name, variant].join(':')
+        ab_test_metatag = page.find("meta[name='govuk:ab-test']", visible: :all)
+
+        expect(ab_test_metatag['content']).to eq(content)
+
+        if dimension.nil?
+          expect(ab_test_metatag['data-analytics-dimension']).to_not be_nil
+        else
+          expect(ab_test_metatag['data-analytics-dimension']).to eq(dimension.to_s)
+        end
+      end
+    end
+  end
+end

--- a/spec/minitest_helpers_spec.rb
+++ b/spec/minitest_helpers_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require './spec/support/fake_minitest_controller_test_case'
 
 class AnExampleMiniTestCase < FakeMinitestControllerTestCase
   include GovukAbTesting::MinitestHelpers

--- a/spec/rspec_capybara_helpers_spec.rb
+++ b/spec/rspec_capybara_helpers_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+require './spec/support/fake_capybara_page'
+
+RSpec.describe GovukAbTesting::RspecCapybaraHelpers do
+  include GovukAbTesting::RspecCapybaraHelpers
+
+  def page
+    @page ||= FakeCapybaraPage.new(:example, 'B', 100)
+  end
+
+  it 'tests the behviour of with_variant' do
+    object = double(call: true)
+    expect(object).to receive(:call)
+
+    with_variant example: 'B' do
+      object.call
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,29 +1,2 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "govuk_ab_testing"
-
-# This class replicates the behaviour of a `ActionController::TestCase` to allow
-# us to test the minitest helpers, in RSpec.
-class FakeMinitestControllerTestCase
-  def initialize
-    @request = FakeRequestResponseObject.new
-  end
-
-  def assert_equal(*)
-  end
-
-  def assert_select(*)
-  end
-
-  def assert_match(*)
-  end
-
-  def response
-    FakeRequestResponseObject.new
-  end
-
-  class FakeRequestResponseObject
-    def headers
-      {}
-    end
-  end
-end

--- a/spec/support/fake_capybara_page.rb
+++ b/spec/support/fake_capybara_page.rb
@@ -1,0 +1,36 @@
+class FakeCapybaraPage
+  attr_reader :ab_test_name, :ab_test_variant, :dimension
+
+  def initialize(ab_test_name, ab_test_variant, dimension)
+    @ab_test_name = ab_test_name
+    @ab_test_variant = ab_test_variant
+    @dimension = dimension
+  end
+
+  def driver
+    @driver ||= FakeCapybaraDriver.new
+  end
+
+  def response_headers
+    {
+      'Vary' => "GOVUK-ABTest-#{ab_test_name}"
+    }
+  end
+
+  def find(*)
+    {
+      'content' => "#{ab_test_name}:#{ab_test_variant}",
+      'data-analytics-dimension' => dimension.to_s
+    }
+  end
+
+  class FakeCapybaraDriver
+    def initialize
+      @headers = {}
+    end
+
+    def header(name, value)
+      @headers[name] = value
+    end
+  end
+end

--- a/spec/support/fake_minitest_controller_test_case.rb
+++ b/spec/support/fake_minitest_controller_test_case.rb
@@ -1,0 +1,26 @@
+# This class replicates the behaviour of a `ActionController::TestCase` to allow
+# us to test the minitest helpers, in RSpec.
+class FakeMinitestControllerTestCase
+  def initialize
+    @request = FakeRequestResponseObject.new
+  end
+
+  def assert_equal(*)
+  end
+
+  def assert_select(*)
+  end
+
+  def assert_match(*)
+  end
+
+  def response
+    FakeRequestResponseObject.new
+  end
+
+  class FakeRequestResponseObject
+    def headers
+      {}
+    end
+  end
+end

--- a/spec/support/fake_minitest_controller_test_case.rb
+++ b/spec/support/fake_minitest_controller_test_case.rb
@@ -5,6 +5,9 @@ class FakeMinitestControllerTestCase
     @request = FakeRequestResponseObject.new
   end
 
+  def assert(*)
+  end
+
   def assert_equal(*)
   end
 
@@ -14,8 +17,28 @@ class FakeMinitestControllerTestCase
   def assert_match(*)
   end
 
+  def css_select(*)
+    [
+      FakeNokogiriElement.new
+    ]
+  end
+
   def response
     FakeRequestResponseObject.new
+  end
+
+  class FakeNokogiriElement
+    def attributes
+      {
+        'content' => FakeNokogiriAttr.new,
+        'data-analytics-dimension' => FakeNokogiriAttr.new
+      }
+    end
+  end
+
+  class FakeNokogiriAttr
+    def value
+    end
   end
 
   class FakeRequestResponseObject


### PR DESCRIPTION
In this PR:

- New helper class to add `with_variant` to RSpec + Capybara tests;
- Test presence of custom dimension in analytics meta tag.

Trello: https://trello.com/c/V6PSacVC/336-changes-to-education-related-content-pages-as-part-of-the-new-navigation-in-manuals-frontend