### PR TITLE
Fix name of assertion method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ class PartyControllerTest < ActionController::TestCase
 
     get :show
 
-    assert_unaffected_by_ab_test
+    assert_response_not_modified_for_ab_test
   end
 end
 ```


### PR DESCRIPTION
`assert_unaffected_by_ab_test` no longer exists, as it has been renamed.

This commit makes sure we have an up-to-date README.