### PR TITLE
Avoid memoising meta tags

### DIFF
--- a/lib/govuk_ab_testing/acceptance_tests/active_support.rb
+++ b/lib/govuk_ab_testing/acceptance_tests/active_support.rb
@@ -22,7 +22,7 @@ module GovukAbTesting
       end
 
       def analytics_meta_tags
-        @analytics_meta_tags ||= scope.css_select(ANALYTICS_META_TAG_SELECTOR)
+        scope.css_select(ANALYTICS_META_TAG_SELECTOR)
       end
 
       def analytics_meta_tag

--- a/lib/govuk_ab_testing/acceptance_tests/capybara.rb
+++ b/lib/govuk_ab_testing/acceptance_tests/capybara.rb
@@ -26,8 +26,7 @@ module GovukAbTesting
       end
 
       def analytics_meta_tags
-        @analytics_meta_tags ||=
-          capybara_page.all(ANALYTICS_META_TAG_SELECTOR, visible: :all)
+        capybara_page.all(ANALYTICS_META_TAG_SELECTOR, visible: :all)
       end
 
       def analytics_meta_tag


### PR DESCRIPTION
If we use `with_variant` more than once in a test case, we would keep
the old value set and the tests could potentially fail.

Trello: https://trello.com/c/t4n8kPpx/434-make-sure-collections-can-be-toggled-with-the-a-b-test-and-react-to-it

This is the cause of a bug reported here: https://github.com/alphagov/government-frontend/pull/264#discussion_r103697916