### PR TITLE
Ensure all test helpers are test framework-agnostic

### DIFF
--- a/lib/govuk_ab_testing/minitest_helpers.rb
+++ b/lib/govuk_ab_testing/minitest_helpers.rb
@@ -56,10 +56,12 @@ module GovukAbTesting
     end
 
     def assert_response_not_modified_for_ab_test
-      assert_nil response.headers['Vary'],
-        "`Vary` header is being added to a page which is outside of the A/B test"
+      assert_nil acceptance_test_framework.vary_header(response),
+        "`Vary` header is being added to a page which should not be modified by the A/B test"
 
-      assert_select "meta[name='govuk:ab-test']", false
+      meta_tags = acceptance_test_framework.analytics_meta_tags
+      assert_equal(0, meta_tags.count,
+        "A/B meta tag is being added to a page which should not be modified by the A/B test")
     end
   end
 end


### PR DESCRIPTION
Update `assert_response_not_modified_for_ab_test` so that it inspects the headers and meta tags using the test framework in the same way as the other test helpers.

@carvil Could you check that I've done the right thing here? I've tested it in both collections and frontend, which use different integration test frameworks.