### PR TITLE
Add more fine-grained test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,32 @@ To test the negative case in which a page is unaffected by the A/B test:
 class PartyControllerTest < ActionController::TestCase
   include GovukAbTesting::MinitestHelpers
 
-  should "show the original " do
+  should "show the original" do
     setup_ab_variant("your_ab_test_name", "B") # optionally pass in a analytics dimension as the third argument
 
     get :show
 
     assert_response_not_modified_for_ab_test
+  end
+end
+```
+
+There are some more fine-grained assertions which you can use to test a page
+with A/B variants which should be cached separately, but which should be
+excluded from the analytics:
+
+```ruby
+# test/controllers/party_controller_test.rb
+class PartyControllerTest < ActionController::TestCase
+  include GovukAbTesting::MinitestHelpers
+
+  should "cache each variant but not add analytics" do
+    setup_ab_variant("your_ab_test_name", "B")
+
+    get :show
+
+    assert_response_is_cached_by_variant("your_ab_test_name")
+    assert_page_not_tracked_in_ab_test
   end
 end
 ```

--- a/lib/govuk_ab_testing/minitest_helpers.rb
+++ b/lib/govuk_ab_testing/minitest_helpers.rb
@@ -55,10 +55,22 @@ module GovukAbTesting
       acceptance_test_framework.set_header(ab_test.request_header, variant)
     end
 
+    def assert_response_is_cached_by_variant(ab_test_name)
+      ab_test = GovukAbTesting::AbTest.new(ab_test_name, dimension: 123)
+
+      vary_header_value = acceptance_test_framework.vary_header(response)
+      assert_match ab_test.response_header, vary_header_value,
+        "You probably forgot to use `configure_response`"
+    end
+
     def assert_response_not_modified_for_ab_test
       assert_nil acceptance_test_framework.vary_header(response),
         "`Vary` header is being added to a page which should not be modified by the A/B test"
 
+      assert_page_not_tracked_in_ab_test
+    end
+
+    def assert_page_not_tracked_in_ab_test
       meta_tags = acceptance_test_framework.analytics_meta_tags
       assert_equal(0, meta_tags.count,
         "A/B meta tag is being added to a page which should not be modified by the A/B test")


### PR DESCRIPTION
Add two new Minitest helpers:
 - Test that the `Vary` header is added
 - Test that the `meta` tag is not added

These can be used to test cases like the Education Navigation on the homepage, where we want to cache the variants separately not but include them in the analytics.

https://trello.com/c/FOUYzmzX/477-change-homepage-topic-and-description-for-education