### PR TITLE
Port individual assertions from Minitest to RSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+* Port the individual set-up and assertion steps from Minitest to RSpec
+
 ## 1.0.3
 
 * Add more Minitest helpers with more fine-grained assertions

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ end
 
 ##### RSpec
 
-It is also possible to use `with_variant` in RSpec tests. Here is an example of
-a spec file:
+It is also possible to use `with_variant` and all the individual setup and
+assertions steps in RSpec tests. Here is an example of a spec file:
 
 ```ruby
 # spec/features/ab_testing_spec.rb

--- a/lib/govuk_ab_testing/rspec_helpers.rb
+++ b/lib/govuk_ab_testing/rspec_helpers.rb
@@ -36,5 +36,32 @@ module GovukAbTesting
         end
       end
     end
+
+    def setup_ab_variant(ab_test_name, variant, dimension = 300)
+      ab_test = GovukAbTesting::AbTest.new(ab_test_name, dimension: dimension)
+
+      acceptance_test_framework.set_header(ab_test.request_header, variant)
+    end
+
+    def assert_response_is_cached_by_variant(ab_test_name)
+      ab_test = GovukAbTesting::AbTest.new(ab_test_name, dimension: 123)
+
+      vary_header_value = acceptance_test_framework.vary_header
+      expect(vary_header_value).to eq(ab_test.response_header)
+    end
+
+    def assert_response_not_modified_for_ab_test
+      expect(acceptance_test_framework.vary_header).to be_nil,
+        "`Vary` header is being added to a page which should not be modified by the A/B test"
+
+      assert_page_not_tracked_in_ab_test
+    end
+
+    def assert_page_not_tracked_in_ab_test
+      meta_tags = acceptance_test_framework.analytics_meta_tags
+
+      expect(meta_tags).to be_empty,
+        "A/B meta tag is being added to a page which should not be modified by the A/B test"
+    end
   end
 end

--- a/lib/govuk_ab_testing/version.rb
+++ b/lib/govuk_ab_testing/version.rb
@@ -1,3 +1,3 @@
 module GovukAbTesting
-  VERSION = "1.0.3".freeze
+  VERSION = "1.0.4".freeze
 end


### PR DESCRIPTION
Add the fine-grained setup and assertion steps to the RSpec test helper so that they can be used from applications like manuals-frontend.

https://trello.com/c/Xehe42eM/464-only-add-a-b-meta-tag-to-pages-in-the-navigation-a-b-test