### PR TITLE
Modify assertions to require A/B test name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+* **BREAKING CHANGE** `assert_response_not_modified_for_ab_test` now
+  requires a parameter to indicate what A/B test we are referring to.
+  This allows for multiple A/B tests to exist without letting the test
+  cases fail in case they encounter a different A/B test in the Vary header;
+* **BREAKING CHANGE** `assert_page_not_tracked_in_ab_test` now also
+  requires a parameter to indicate what A/B test we are referring to.
+  The reason is similar to the one mentioned above;
+* New class introduced to represent a meta tag. This lets us query if a
+  given meta tag belongs to a given A/B test.
+
 ## 1.0.4
 
 * Port the individual set-up and assertion steps from Minitest to RSpec

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ class PartyControllerTest < ActionController::TestCase
 
     get :show
 
-    assert_response_not_modified_for_ab_test
+    assert_response_not_modified_for_ab_test("your_ab_test_name")
   end
 end
 ```
@@ -152,7 +152,7 @@ class PartyControllerTest < ActionController::TestCase
     get :show
 
     assert_response_is_cached_by_variant("your_ab_test_name")
-    assert_page_not_tracked_in_ab_test
+    assert_page_not_tracked_in_ab_test("your_ab_test_name")
   end
 end
 ```

--- a/lib/govuk_ab_testing.rb
+++ b/lib/govuk_ab_testing.rb
@@ -4,6 +4,7 @@ require "govuk_ab_testing/requested_variant"
 require "govuk_ab_testing/ab_test"
 require "govuk_ab_testing/minitest_helpers"
 require "govuk_ab_testing/rspec_helpers"
+require 'govuk_ab_testing/acceptance_tests/meta_tag'
 require 'govuk_ab_testing/acceptance_tests/capybara'
 require 'govuk_ab_testing/acceptance_tests/active_support'
 

--- a/lib/govuk_ab_testing/acceptance_tests/active_support.rb
+++ b/lib/govuk_ab_testing/acceptance_tests/active_support.rb
@@ -21,20 +21,19 @@ module GovukAbTesting
         response.headers['Vary']
       end
 
+      def analytics_meta_tags_for_test(ab_test_name)
+        analytics_meta_tags.select { |tag| tag.for_ab_test?(ab_test_name) }
+      end
+
       def analytics_meta_tags
-        scope.css_select(ANALYTICS_META_TAG_SELECTOR)
-      end
+        tags = scope.css_select(ANALYTICS_META_TAG_SELECTOR)
 
-      def analytics_meta_tag
-        analytics_meta_tags.first
-      end
-
-      def content
-        analytics_meta_tag.attributes['content'].value
-      end
-
-      def dimension
-        analytics_meta_tag.attributes['data-analytics-dimension'].value
+        tags.map do |tag|
+          MetaTag.new(
+            content: tag.attributes['content'].value,
+            dimension: tag.attributes['data-analytics-dimension'].value
+          )
+        end
       end
     end
   end

--- a/lib/govuk_ab_testing/acceptance_tests/capybara.rb
+++ b/lib/govuk_ab_testing/acceptance_tests/capybara.rb
@@ -25,20 +25,19 @@ module GovukAbTesting
         capybara_page.response_headers['Vary']
       end
 
+      def analytics_meta_tags_for_test(ab_test_name)
+        analytics_meta_tags.select { |tag| tag.for_ab_test?(ab_test_name) }
+      end
+
       def analytics_meta_tags
-        capybara_page.all(ANALYTICS_META_TAG_SELECTOR, visible: :all)
-      end
+        tags = capybara_page.all(ANALYTICS_META_TAG_SELECTOR, visible: :all)
 
-      def analytics_meta_tag
-        analytics_meta_tags.first
-      end
-
-      def content
-        analytics_meta_tag['content']
-      end
-
-      def dimension
-        analytics_meta_tag['data-analytics-dimension']
+        tags.map do |tag|
+          MetaTag.new(
+            content: tag['content'],
+            dimension: tag['data-analytics-dimension']
+          )
+        end
       end
     end
   end

--- a/lib/govuk_ab_testing/acceptance_tests/meta_tag.rb
+++ b/lib/govuk_ab_testing/acceptance_tests/meta_tag.rb
@@ -1,0 +1,16 @@
+module GovukAbTesting
+  module AcceptanceTests
+    class MetaTag
+      attr_reader :content, :dimension
+
+      def initialize(content:, dimension:)
+        @content = content
+        @dimension = dimension
+      end
+
+      def for_ab_test?(ab_test_name)
+        content.match(/#{ab_test_name}/i)
+      end
+    end
+  end
+end

--- a/spec/meta_tag_spec.rb
+++ b/spec/meta_tag_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe GovukAbTesting::AcceptanceTests::MetaTag do
+  let(:meta_tag) do
+    described_class.new(content: 'ABTest:B', dimension: 100)
+  end
+
+  describe '#for_ab_test?' do
+    context 'with a matching A/B test name' do
+      it 'is truthy' do
+        expect(meta_tag.for_ab_test?('ABTest')).to be_truthy
+      end
+    end
+
+    context 'without a matching A/B test name' do
+      it 'is falsy' do
+        expect(meta_tag.for_ab_test?('UnknownTest')).to be_falsy
+      end
+    end
+  end
+end

--- a/spec/support/fake_minitest_controller_test_case.rb
+++ b/spec/support/fake_minitest_controller_test_case.rb
@@ -38,6 +38,7 @@ class FakeMinitestControllerTestCase
 
   class FakeNokogiriAttr
     def value
+      "example"
     end
   end
 


### PR DESCRIPTION
This commit modifies the following assertions in both `Minitest` and
`RSpec` classes:

- `assert_response_is_cached_by_variant`
- `assert_response_not_modified_for_ab_test`

Both assertions now require a new parameter `ab_test_name`, which
indicates what A/B test we are running the assertions against.

This change is needed in case we are running more than 1 A/B test in a
given page.

This commit also introduces a `MetaTag` class which allows us to query
if a given meta tag belongs to a particular A/B test.

Related trello card: https://trello.com/c/NJ6O76BR/281-heatmap-tracking