### PR TITLE
Fix empty assertion helper

### DIFF
--- a/lib/govuk_ab_testing/abstract_helpers.rb
+++ b/lib/govuk_ab_testing/abstract_helpers.rb
@@ -64,10 +64,8 @@ module GovukAbTesting
       assert_is_empty(
         enumerable: ab_test_meta_tags,
         error_message: <<-ERROR
-          Found the following '#{ab_test_name}' A/B testing meta tag on a page that should not be modified by
-          the A/B test:
-
-            #{ab_test_meta_tags.first.content}
+          Found the '#{ab_test_name}' A/B testing meta tag on a page that should not be modified by
+          the A/B test.
 
           Check for incorrect usage of GovukAbTesting::RequestedVariant#analytics_meta_tag
         ERROR

--- a/lib/govuk_ab_testing/minitest_assertions.rb
+++ b/lib/govuk_ab_testing/minitest_assertions.rb
@@ -17,7 +17,7 @@ module GovukAbTesting
     end
 
     def assert_is_empty(enumerable:, error_message:)
-      assert_has_size(enumerable, 0, error_message)
+      assert_has_size(enumerable: enumerable, size: 0, error_message: error_message)
     end
 
     def assert_not_blank(string:, error_message:)


### PR DESCRIPTION
- Removed string interpolation for parameters that may potentially be nil in some test uses.
- Add key name parameters for helper methods that require it.

https://trello.com/c/43eBQfwf/80-prepare-the-infrastructure-for-the-minimum-should-match-a-b-test