### PR TITLE
Don’t memoize Active Support request/response in test helpers

### DIFF
--- a/lib/govuk_ab_testing/acceptance_tests/active_support.rb
+++ b/lib/govuk_ab_testing/acceptance_tests/active_support.rb
@@ -1,16 +1,23 @@
 module GovukAbTesting
   module AcceptanceTests
     class ActiveSupport
-      attr_reader :request, :request_headers, :scope
+      attr_reader :request_headers, :scope
 
       def initialize(scope)
-        @request = scope.instance_variable_get(:@request)
-        if @request.nil?
-          raise "Couldn't find '@request' defined, are you using ActiveSupport test cases?"
-        end
         @scope = scope
         @request_headers = {}
-        @response = scope.instance_variable_get(:@response)
+
+        if request.nil?
+          raise "Couldn't find '@request' defined, are you using ActiveSupport test cases?"
+        end
+      end
+
+      def request
+        @scope.instance_variable_get(:@request)
+      end
+
+      def response
+        @scope.instance_variable_get(:@response)
       end
 
       def set_header(name, value)
@@ -19,7 +26,7 @@ module GovukAbTesting
       end
 
       def vary_header
-        @response.headers['Vary']
+        response.headers['Vary']
       end
 
       def analytics_meta_tags_for_test(ab_test_name)


### PR DESCRIPTION
Upgrading to Rails 5.0.2 appears to break the AB Test helpers.
It appears that the `@response` object is being reassigned midway
through tests.

The Active Support helper previously memoized the `@request` and
`@response` objects. However, since these objects appear to change
partway through the tests, the test helper then references the “wrong”
object.

This change forces us to look up the `@request` and `@response` objects
each time they are requested of the test helper.