### PR TITLE
Allow multiple headers to be set in Capybara

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Fix bug in order to allow us to set multiple headers (i.e. A/B tests) in a
+  test using Capybara. This is important when running multiple A/B tests at
+  once.
+
 ## 2.3.0
 
 * Fix for Rails 5.0.2 - the Active Support acceptance tests used to memoize

--- a/lib/govuk_ab_testing/acceptance_tests/capybara.rb
+++ b/lib/govuk_ab_testing/acceptance_tests/capybara.rb
@@ -16,7 +16,8 @@ module GovukAbTesting
       end
 
       def set_header(name, value)
-        capybara_page.driver.options[:headers] = { name => value }
+        capybara_page.driver.options[:headers] ||= {}
+        capybara_page.driver.options[:headers][name] = value
         capybara_page.driver.header(name, value)
         @request_headers[name] = value
       end

--- a/spec/acceptance_tests/capybara_spec.rb
+++ b/spec/acceptance_tests/capybara_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe GovukAbTesting::AcceptanceTests::Capybara do
+  let(:capybara_acceptance_test) do
+    driver = double(options: {}, header: true)
+    page = double('Capybara::Session', driver: driver)
+    scope = double(page: page)
+
+    described_class.new(scope)
+  end
+
+  it 'is possible to set multiple headers' do
+    capybara_acceptance_test.set_header('ABTest-1', 'A')
+    capybara_acceptance_test.set_header('ABTest-2', 'B')
+
+    request_headers = capybara_acceptance_test.request.driver.options[:headers]
+
+    expect(request_headers['ABTest-1']).to eq('A')
+    expect(request_headers['ABTest-2']).to eq('B')
+  end
+end


### PR DESCRIPTION
Currently, we were overriding the headers when setting them in Capybara.
Now that we have applications adding more than 1 A/B test at once, we
need to retain the information about all A/B tests in the headers for
the tests to work.

Related to work being done on this trello card: https://trello.com/c/S5jp2jih/179-setup-technical-implementation-for-a-b-testing-the-blue-box