### PR TITLE
Allow for custom variant names in A/B tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+* Add new method to `RequestedVariant` to query if a user is in a given variant.
+  The method is `variant?(name)`, where `name` is the name of the variant.
+  This new method allows for generic variant names, which are useful when
+  reusing A/B testing cookies/headers. If the cookie name and header name are
+  generic, the variant value should provide details on what test is running.
+* Add deprecation warnings to `variant_a?` and `variant_b?`, as they will be
+  replaced by the method `variant?(name)`.
+
 ## 2.3.1
 
 * Fix bug in order to allow us to set multiple headers (i.e. A/B tests) in a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Add two new optional parameters to `GovukAbTesting::AbTest`:
+  `allowed_variants` and `control_variant`. These allow us to override the
+  traditional naming of the A/B tests and also setup a multivariate test if
+  needed.
 * Add new method to `RequestedVariant` to query if a user is in a given variant.
   The method is `variant?(name)`, where `name` is the name of the variant.
   This new method allows for generic variant names, which are useful when

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ class PartyController < ApplicationController
     @requested_variant = ab_test.requested_variant(request.headers)
     @requested_variant.configure_response(response)
 
-    if @requested_variant.variant_b?
+    if @requested_variant.variant?('B')
       render "new_show_template_to_be_tested"
     else
       render "show"

--- a/lib/govuk_ab_testing/ab_test.rb
+++ b/lib/govuk_ab_testing/ab_test.rb
@@ -2,15 +2,22 @@ module GovukAbTesting
   class AbTest
     attr_reader :ab_test_name
     attr_reader :dimension
+    attr_reader :allowed_variants
+    attr_reader :control_variant
 
     alias_method :name, :ab_test_name
 
     # @param request [String] the name of the A/B test
     # @param dimension [Integer] the dimension registered with Google Analytics
     # for this specific A/B test
-    def initialize(ab_test_name, dimension:)
+    # @param allowed_variants [Array] an array of Strings representing the
+    # possible variants
+    # @param control_variant [String] the control variant (typically 'A')
+    def initialize(ab_test_name, dimension:, allowed_variants: %w(A B), control_variant: 'A')
       @ab_test_name = ab_test_name
       @dimension = dimension
+      @allowed_variants = allowed_variants
+      @control_variant = control_variant
     end
 
     # @param request [ActionDispatch::Http::Headers] the `request.headers` in

--- a/lib/govuk_ab_testing/requested_variant.rb
+++ b/lib/govuk_ab_testing/requested_variant.rb
@@ -22,12 +22,25 @@ module GovukAbTesting
 
     # @return [Boolean] if the user is to be served variant A
     def variant_a?
+      warn 'DEPRECATION WARNING: the method `variant_a?` is deprecated. use `variant?("A")` instead'
+
       variant_name == "A"
     end
 
     # @return [Boolean] if the user is to be served variant B
     def variant_b?
+      warn 'DEPRECATION WARNING: the method `variant_b?` is deprecated. use `variant?("B")` instead'
+
       variant_name == "B"
+    end
+
+    # Check if the user should be served a specific variant
+    #
+    # @param [String or Symbol] the name of the variant
+    #
+    # @return [Boolean] if the user is to be served variant :name
+    def variant?(name)
+      request_headers[ab_test.request_header] == name.to_s
     end
 
     # Configure the response
@@ -42,7 +55,8 @@ module GovukAbTesting
     # @return [String]
     def analytics_meta_tag
       '<meta name="govuk:ab-test" ' +
-        'content="' + ab_test.meta_tag_name + ':' + variant_name + '" ' +
+        'content="' + ab_test.meta_tag_name + ':' +
+        request_headers[ab_test.request_header] + '" ' +
         'data-analytics-dimension="' + @dimension.to_s + '">'
     end
   end

--- a/lib/govuk_ab_testing/requested_variant.rb
+++ b/lib/govuk_ab_testing/requested_variant.rb
@@ -17,7 +17,11 @@ module GovukAbTesting
     #
     # @return [String] the current variant, "A" or "B"
     def variant_name
-      request_headers[ab_test.request_header] == "B" ? "B" : "A"
+      variant = ab_test.allowed_variants.find do |allowed_variant|
+        allowed_variant == request_headers[ab_test.request_header]
+      end
+
+      variant || ab_test.control_variant
     end
 
     # @return [Boolean] if the user is to be served variant A
@@ -40,7 +44,7 @@ module GovukAbTesting
     #
     # @return [Boolean] if the user is to be served variant :name
     def variant?(name)
-      request_headers[ab_test.request_header] == name.to_s
+      variant_name == name.to_s
     end
 
     # Configure the response
@@ -55,9 +59,9 @@ module GovukAbTesting
     # @return [String]
     def analytics_meta_tag
       '<meta name="govuk:ab-test" ' +
-        'content="' + ab_test.meta_tag_name + ':' +
-        request_headers[ab_test.request_header] + '" ' +
-        'data-analytics-dimension="' + @dimension.to_s + '">'
+        'content="' + ab_test.meta_tag_name + ':' + variant_name + '" ' +
+        'data-analytics-dimension="' + @dimension.to_s + '" ' +
+        'data-allowed-variants="' + ab_test.allowed_variants.join(',') + '">'
     end
   end
 end

--- a/lib/govuk_ab_testing/requested_variant.rb
+++ b/lib/govuk_ab_testing/requested_variant.rb
@@ -44,6 +44,11 @@ module GovukAbTesting
     #
     # @return [Boolean] if the user is to be served variant :name
     def variant?(name)
+      error_message =
+        "Invalid variant name '#{name}'. Allowed variants are: #{ab_test.allowed_variants}"
+
+      raise error_message unless ab_test.allowed_variants.include?(name.to_s)
+
       variant_name == name.to_s
     end
 

--- a/spec/requested_variant_spec.rb
+++ b/spec/requested_variant_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe GovukAbTesting::RequestedVariant do
         requested_variant(request_headers)
 
       expect(requested_variant.analytics_meta_tag).to eql(
-        "<meta name=\"govuk:ab-test\" content=\"EducationNav:A\" data-analytics-dimension=\"207\">")
+        "<meta name=\"govuk:ab-test\" content=\"EducationNav:A\" data-analytics-dimension=\"207\" data-allowed-variants=\"A,B\">")
     end
   end
 
@@ -79,6 +79,46 @@ RSpec.describe GovukAbTesting::RequestedVariant do
       requested_variant.configure_response(response)
 
       expect(response.headers['Vary']).to eql('GOVUK-OtherHeader, GOVUK-ABTest-EducationNav')
+    end
+  end
+
+  context 'with custom variants' do
+    let(:ab_test) {
+      GovukAbTesting::AbTest.new(
+        "NewTitleTest",
+        dimension: 500,
+        allowed_variants: %w(NoTitleChange Title1 Title2),
+        control_variant: 'NoTitleChange'
+      )
+    }
+
+    describe '#variant_name' do
+      %w(NoTitleChange Title1 Title2).each do |variant_name|
+        it "returns the variant '#{variant_name}' when the header exists" do
+          request_headers = { 'HTTP_GOVUK_ABTEST_NEWTITLETEST' => variant_name }
+
+          requested_variant = ab_test.requested_variant(request_headers)
+
+          expect(requested_variant.variant_name).to eql(variant_name)
+        end
+      end
+
+      it 'defaults to the control group when no header is given' do
+        requested_variant = ab_test.requested_variant({})
+
+        expect(requested_variant.variant_name).to eql("NoTitleChange")
+      end
+    end
+
+    describe '#analytics_meta_tag' do
+      it "returns the tag with the analytics dimension" do
+        request_headers = { 'HTTP_GOVUK_ABTEST_NEWTITLETEST' => 'Title1' }
+
+        requested_variant = ab_test.requested_variant(request_headers)
+
+        expect(requested_variant.analytics_meta_tag).to eql(
+          "<meta name=\"govuk:ab-test\" content=\"NewTitleTest:Title1\" data-analytics-dimension=\"500\" data-allowed-variants=\"NoTitleChange,Title1,Title2\">")
+      end
     end
   end
 end

--- a/spec/requested_variant_spec.rb
+++ b/spec/requested_variant_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe GovukAbTesting::RequestedVariant do
     end
   end
 
+  describe '#variant?' do
+    it "returns the variant" do
+      request_headers = { 'HTTP_GOVUK_ABTEST_EDUCATIONNAV' => 'B' }
+
+      requested_variant = ab_test.requested_variant(request_headers)
+
+      expect(requested_variant.variant?('A')).to eql(false)
+      expect(requested_variant.variant?('B')).to eql(true)
+    end
+  end
+
   describe '#analytics_meta_tag' do
     it "returns the tag with the analytics dimension" do
       request_headers = { 'HTTP_GOVUK_ABTEST_EDUCATIONNAV' => 'A' }

--- a/spec/requested_variant_spec.rb
+++ b/spec/requested_variant_spec.rb
@@ -46,6 +46,18 @@ RSpec.describe GovukAbTesting::RequestedVariant do
       expect(requested_variant.variant?('A')).to eql(false)
       expect(requested_variant.variant?('B')).to eql(true)
     end
+
+    it 'raises with an invalid variant name' do
+      request_headers = { 'HTTP_GOVUK_ABTEST_EDUCATIONNAV' => 'B' }
+
+      requested_variant = ab_test.requested_variant(request_headers)
+
+      expect {
+        requested_variant.variant?('InvalidName')
+      }.to raise_error(
+        "Invalid variant name 'InvalidName'. Allowed variants are: #{ab_test.allowed_variants}"
+      )
+    end
   end
 
   describe '#analytics_meta_tag' do


### PR DESCRIPTION
In this PR, I've:
- Introduce a new method called `variant?(name)`;
- deprecates `variant_a?` and `variant_b?`;
- allow for custom variant names;
- allow for an arbitrary number of variants (multivariate testing). 

The new method `variant?(name)` allows for generic variant names to be used in A/B tests besides just A and B. The reason for this is so we can re-use a generic A/B test setup across different A/B tests. In the Navigation team, we have 1 long running A/B test for the new navigation called `EducationNavigation`. We would like to conduct other short-lived A/B tests within to improve the new navigation. Because of limitations in the number of custom dimensions we can have in Google Analytics, we agreed to create one generic A/B test (`NavigationTest`) and recycle it when we are done with a specific test after 15 days or so. This means that the variant name needs to provide more insight into what's being tested. In our case, we are starting with `NoBlueBox` as the typical `A` group (no change), and `ShowBlueBox` for the `B` group (with the changes in place). By adding those verbose variant names, it will be clearer from an analytics perspective what we are testing.

In order to configure the A/B test with custom variant names, we can set it up as this:

```
GovukAbTesting::AbTest.new(
  "MyTest",
  dimension: 500,
  allowed_variants: ['NoChange', 'Test1', 'Test2'],
  control_variant: 'NoChange'
)
```

We can then query what variant we are on with `variant?('Test1')`.

The `allowed_variants` are then added to the analytics meta tag, so the chrome extension can pick them up and display what to toggle to/from.

Finally, we add all available variants to the analytics meta tag so it can be picked up by the Chrome extension. Since we are no longer just interested in A or B, we need the extension to know what variants are available to switch to.

Related to this trello card: https://trello.com/c/S5jp2jih/179-setup-technical-implementation-for-a-b-testing-the-blue-box

What do you think?