### PR TITLE
 Check page body exists before running assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+* Add extra validation to ActiveSupport assertions to help debug test failures.
+  In order to make assertions about the `meta` tags, the view must be rendered
+  in the test. RSpec Rails tests do not do this by default, so you need to call
+  `render_views` explicitly. Without this check, tests fail with a cryptic error
+  message "undefined method 'document' for nil:NilClass".
+
 ## 2.4.0
 
 * Add two new optional parameters to `GovukAbTesting::AbTest`:

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ end
 ##### RSpec
 
 It is also possible to use `with_variant` and all the individual setup and
-assertions steps in RSpec tests. Here is an example of a spec file:
+assertions steps in RSpec tests. Here is an example of a Capybara feature file:
 
 ```ruby
 # spec/features/ab_testing_spec.rb
@@ -185,6 +185,24 @@ feature "Viewing a page with an A/B test" do
 
       expect(page).to have_breadcrumbs
       expect(page).to have_beta_label
+    end
+  end
+end
+```
+
+And here is an RSpec controller test:
+
+```ruby
+# spec/controllers/some_controller_spec.rb
+describe SomeController, type :controller do
+  include GovukAbTesting::RspecHelpers
+
+  # RSpec doesn't render views for controller specs by default
+  render_views
+
+  it "should render the B version of the page" do
+    with_variant your_ab_test_name: 'B' do
+      get :index
     end
   end
 end

--- a/lib/govuk_ab_testing/acceptance_tests/active_support.rb
+++ b/lib/govuk_ab_testing/acceptance_tests/active_support.rb
@@ -34,6 +34,11 @@ module GovukAbTesting
       end
 
       def analytics_meta_tags
+        if scope.response.body.empty?
+          raise "Cannot find response body. If this is an RSpec Rails test, " +
+            "check that 'render_views' is being called."
+        end
+
         tags = scope.css_select(ANALYTICS_META_TAG_SELECTOR)
 
         tags.map do |tag|

--- a/spec/support/fake_minitest_controller_test_case.rb
+++ b/spec/support/fake_minitest_controller_test_case.rb
@@ -53,5 +53,9 @@ class FakeMinitestControllerTestCase
     def headers
       {}
     end
+
+    def body
+      "some content in the page body"
+    end
   end
 end


### PR DESCRIPTION
Add extra validation to ActiveSupport assertions to help debug test failures.

In order to make assertions about the `meta` tags, the view must be rendered in the test. RSpec Rails tests do not do this by default, so you need to call `render_views` explicitly. Without this check, tests fail with a cryptic error message "undefined method 'document' for nil:NilClass".

Also add an RSpec Rails example to the README.

https://trello.com/c/JJ3mIOP1/392-configure-format-weighting-a-b-test-in-frontend

cc @brenetic 