### PR TITLE
Bump to 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.4.2
 
 * Updated gem dependencies and development ruby version to 2.6.6
 * Fixed new rubocop violations

--- a/lib/govuk_ab_testing/version.rb
+++ b/lib/govuk_ab_testing/version.rb
@@ -1,3 +1,3 @@
 module GovukAbTesting
-  VERSION = "2.4.1".freeze
+  VERSION = "2.4.2".freeze
 end


### PR DESCRIPTION
* Updated gem dependencies and development ruby version to 2.6.6
* Fixed new rubocop violations