### PR TITLE
Remove custom dimension from AB test configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
 * Drop support for Ruby 3.0. The minimum required Ruby version is now 3.1
+* **BREAKING CHANGE** No longer allow a GA custom dimension to be passed
+  when creating a GovukAbTesting::AbTest object. The dimension parameter
+  needs to be removed.
 
 ## 2.4.3
 

--- a/README.md
+++ b/README.md
@@ -18,19 +18,18 @@ And then execute:
 
 Before starting this, you'll need to:
 
-- [Read the documentation](https://docs.publishing.service.gov.uk/manual/ab-testing.html) for an overview on how a/b testing works on GOV.UK. 
+- [Read the documentation](https://docs.publishing.service.gov.uk/manual/ab-testing.html) for an overview on how a/b testing works on GOV.UK.
 - The cookie and header name in [govuk-cdn-config](https://github.com/alphagov/govuk-cdn-config/blob/master/ab_tests/ab_tests.yaml) must match the test name parameter that you pass to the Gem. The cookie name is case-sensitive.
 
 ## Usage
 
-### Outline 
+### Outline
 
 To enable testing in the app, your Rails app needs:
 
 1. [Some piece of logic to be A/B tested](#1-example-ab-test-logic)
 2. [A response HTTP header that tells Fastly you're doing an A/B test](#2-http-response-header-to-fastly)
-3. [A HTML meta tag that will be used to measure the results, and which specifies
-   the dimension to use in Google Analytics](#3-add-html-metatag-tags-to-your-layouts)
+3. [A HTML meta tag that will be used to measure the results in Google Analytics](#3-add-html-metatag-tags-to-your-layouts)
 
 ### 1. Example A/B test logic
 
@@ -42,7 +41,6 @@ class PartyController < ApplicationController
   def show
     ab_test = GovukAbTesting::AbTest.new(
       "your_ab_test_name",
-      dimension: 300,
       allowed_variants: ['NoChange', 'LongTitle', 'ShortTitle'],
       control_variant: 'NoChange'
     )
@@ -63,7 +61,7 @@ end
 
 In this example, we are running a multivariate test with 3 options being
 tested: the existing version (control), and two title changes. The minimum
-number of variants in any test should be two. 
+number of variants in any test should be two.
 
 ### 2. HTTP response header to Fastly
 
@@ -148,7 +146,6 @@ As with the `minitest` version, you can also pass in the following options to
 `with_variant`:
 
 - `assert_meta_tag: false`
-- `dimension: <number>`
 
 #### Minitest
 
@@ -200,7 +197,7 @@ class PartyControllerTest < ActionController::TestCase
   include GovukAbTesting::MinitestHelpers
 
   should "show the original" do
-    setup_ab_variant("your_ab_test_name", "B") # optionally pass in a analytics dimension as the third argument
+    setup_ab_variant("your_ab_test_name", "B")
 
     get :show
 

--- a/lib/govuk_ab_testing/ab_test.rb
+++ b/lib/govuk_ab_testing/ab_test.rb
@@ -1,18 +1,15 @@
 module GovukAbTesting
   class AbTest
-    attr_reader :ab_test_name, :dimension, :allowed_variants, :control_variant
+    attr_reader :ab_test_name, :allowed_variants, :control_variant
 
     alias_method :name, :ab_test_name
 
     # @param request [String] the name of the A/B test
-    # @param dimension [Integer] the dimension registered with Google Analytics
-    # for this specific A/B test
     # @param allowed_variants [Array] an array of Strings representing the
     # possible variants
     # @param control_variant [String] the control variant (typically 'A')
-    def initialize(ab_test_name, dimension:, allowed_variants: %w[A B], control_variant: "A")
+    def initialize(ab_test_name, allowed_variants: %w[A B], control_variant: "A")
       @ab_test_name = ab_test_name
-      @dimension = dimension
       @allowed_variants = allowed_variants
       @control_variant = control_variant
     end
@@ -20,7 +17,7 @@ module GovukAbTesting
     # @param request [ActionDispatch::Http::Headers] the `request.headers` in
     # the controller.
     def requested_variant(request_headers)
-      RequestedVariant.new(self, request_headers, @dimension)
+      RequestedVariant.new(self, request_headers)
     end
 
     # Internal name of the header

--- a/lib/govuk_ab_testing/abstract_helpers.rb
+++ b/lib/govuk_ab_testing/abstract_helpers.rb
@@ -6,26 +6,25 @@ module GovukAbTesting
 
     def with_variant(args)
       ab_test_name, variant = args.first
-      dimension = args[:dimension]
 
-      setup_ab_variant(ab_test_name, variant, dimension)
+      setup_ab_variant(ab_test_name, variant)
 
       yield
 
       assert_response_is_cached_by_variant(ab_test_name)
 
       unless args[:assert_meta_tag] == false
-        assert_page_tracked_in_ab_test(ab_test_name, variant, dimension)
+        assert_page_tracked_in_ab_test(ab_test_name, variant)
       end
     end
 
-    def setup_ab_variant(ab_test_name, variant, dimension = 300)
-      ab_test = AbTest.new(ab_test_name, dimension:)
+    def setup_ab_variant(ab_test_name, variant)
+      ab_test = AbTest.new(ab_test_name)
       acceptance_test_framework.set_header(ab_test.request_header, variant)
     end
 
     def assert_response_is_cached_by_variant(ab_test_name)
-      ab_test = AbTest.new(ab_test_name, dimension: 300)
+      ab_test = AbTest.new(ab_test_name)
       vary_header_value = acceptance_test_framework.vary_header
 
       assert_contains_substring(
@@ -72,8 +71,8 @@ module GovukAbTesting
       )
     end
 
-    def assert_page_tracked_in_ab_test(ab_test_name, variant, dimension)
-      ab_test = AbTest.new(ab_test_name, dimension:)
+    def assert_page_tracked_in_ab_test(ab_test_name, variant)
+      ab_test = AbTest.new(ab_test_name)
 
       ab_test_meta_tags =
         acceptance_test_framework.analytics_meta_tags_for_test(ab_test.name)
@@ -104,23 +103,6 @@ module GovukAbTesting
 
         ERROR
       )
-
-      assert_not_blank(
-        string: meta_tag.dimension,
-        error_message: <<-ERROR,
-          The meta tag dimension for the '#{ab_test_name}' A/B test is blank.
-        ERROR
-      )
-
-      unless ab_test.dimension.nil?
-        assert_is_equal(
-          expected: ab_test.dimension.to_s,
-          actual: meta_tag.dimension.to_s,
-          error_message: <<-ERROR,
-            The analytics meta tag for the '#{ab_test.name}' A/B test does not match the expected value.
-          ERROR
-        )
-      end
     end
   end
 end

--- a/lib/govuk_ab_testing/acceptance_tests/active_support.rb
+++ b/lib/govuk_ab_testing/acceptance_tests/active_support.rb
@@ -44,7 +44,6 @@ module GovukAbTesting
         tags.map do |tag|
           MetaTag.new(
             content: tag.attributes["content"].value,
-            dimension: tag.attributes["data-analytics-dimension"].value,
           )
         end
       end

--- a/lib/govuk_ab_testing/acceptance_tests/capybara.rb
+++ b/lib/govuk_ab_testing/acceptance_tests/capybara.rb
@@ -37,7 +37,6 @@ module GovukAbTesting
         tags.map do |tag|
           MetaTag.new(
             content: tag["content"],
-            dimension: tag["data-analytics-dimension"],
           )
         end
       end

--- a/lib/govuk_ab_testing/acceptance_tests/meta_tag.rb
+++ b/lib/govuk_ab_testing/acceptance_tests/meta_tag.rb
@@ -1,11 +1,10 @@
 module GovukAbTesting
   module AcceptanceTests
     class MetaTag
-      attr_reader :content, :dimension
+      attr_reader :content
 
-      def initialize(content:, dimension:)
+      def initialize(content:)
         @content = content
-        @dimension = dimension
       end
 
       def for_ab_test?(ab_test_name)

--- a/lib/govuk_ab_testing/requested_variant.rb
+++ b/lib/govuk_ab_testing/requested_variant.rb
@@ -5,12 +5,9 @@ module GovukAbTesting
     # @param ab_test [AbTest] the A/B test being performed
     # @param request_headers [ActionDispatch::Http::Headers] the
     # `request.headers` in the controller.
-    # @param dimension [Integer] the dimension registered with Google Analytics
-    # for this specific A/B test
-    def initialize(ab_test, request_headers, dimension)
+    def initialize(ab_test, request_headers)
       @ab_test = ab_test
       @request_headers = request_headers
-      @dimension = dimension
     end
 
     # Get the bucket this user is in
@@ -66,7 +63,6 @@ module GovukAbTesting
       tag = <<~HTML
         <meta name="govuk:ab-test"
           content="#{ab_test.meta_tag_name}:#{variant_name}"
-          data-analytics-dimension="#{@dimension}"
           data-allowed-variants="#{ab_test.allowed_variants.join(',')}">
       HTML
 

--- a/spec/meta_tag_spec.rb
+++ b/spec/meta_tag_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe GovukAbTesting::AcceptanceTests::MetaTag do
   let(:meta_tag) do
-    described_class.new(content: "ABTest:B", dimension: 100)
+    described_class.new(content: "ABTest:B")
   end
 
   describe "#for_ab_test?" do

--- a/spec/requested_variant_spec.rb
+++ b/spec/requested_variant_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe GovukAbTesting::RequestedVariant do
   def ab_test
-    GovukAbTesting::AbTest.new("EducationNav", dimension: 500)
+    GovukAbTesting::AbTest.new("EducationNav")
   end
 
   describe "#variant_name" do
@@ -61,16 +61,15 @@ RSpec.describe GovukAbTesting::RequestedVariant do
   end
 
   describe "#analytics_meta_tag" do
-    it "returns the tag with the analytics dimension" do
+    it "returns the tag with the analytics data" do
       request_headers = { "HTTP_GOVUK_ABTEST_EDUCATIONNAV" => "A" }
 
-      requested_variant = GovukAbTesting::AbTest.new("EducationNav", dimension: 207)
+      requested_variant = GovukAbTesting::AbTest.new("EducationNav")
         .requested_variant(request_headers)
 
       expected = <<~HTML
         <meta name="govuk:ab-test"
           content="EducationNav:A"
-          data-analytics-dimension="207"
           data-allowed-variants="A,B">
       HTML
 
@@ -106,7 +105,6 @@ RSpec.describe GovukAbTesting::RequestedVariant do
     let(:ab_test) do
       GovukAbTesting::AbTest.new(
         "NewTitleTest",
-        dimension: 500,
         allowed_variants: %w[NoTitleChange Title1 Title2],
         control_variant: "NoTitleChange",
       )
@@ -131,7 +129,7 @@ RSpec.describe GovukAbTesting::RequestedVariant do
     end
 
     describe "#analytics_meta_tag" do
-      it "returns the tag with the analytics dimension" do
+      it "returns the tag with the analytics data" do
         request_headers = { "HTTP_GOVUK_ABTEST_NEWTITLETEST" => "Title1" }
 
         requested_variant = ab_test.requested_variant(request_headers)
@@ -139,7 +137,6 @@ RSpec.describe GovukAbTesting::RequestedVariant do
         expected = <<~HTML
           <meta name="govuk:ab-test"
             content="NewTitleTest:Title1"
-            data-analytics-dimension="500"
             data-allowed-variants="NoTitleChange,Title1,Title2">
         HTML
 

--- a/spec/rspec_helpers_spec.rb
+++ b/spec/rspec_helpers_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe GovukAbTesting::RspecHelpers do
   include GovukAbTesting::RspecHelpers
 
   def page
-    @page ||= FakeCapybaraPage.new(:example, "B", 100)
+    @page ||= FakeCapybaraPage.new(:example, "B")
   end
 
   it "tests the behviour of with_variant" do

--- a/spec/support/fake_capybara_page.rb
+++ b/spec/support/fake_capybara_page.rb
@@ -1,10 +1,9 @@
 class FakeCapybaraPage
-  attr_reader :ab_test_name, :ab_test_variant, :dimension
+  attr_reader :ab_test_name, :ab_test_variant
 
-  def initialize(ab_test_name, ab_test_variant, dimension)
+  def initialize(ab_test_name, ab_test_variant)
     @ab_test_name = ab_test_name
     @ab_test_variant = ab_test_variant
-    @dimension = dimension
   end
 
   def driver
@@ -20,7 +19,6 @@ class FakeCapybaraPage
   def all(*)
     [{
       "content" => "#{ab_test_name}:#{ab_test_variant}",
-      "data-analytics-dimension" => dimension.to_s,
     }]
   end
 

--- a/spec/support/fake_minitest_controller_test_case.rb
+++ b/spec/support/fake_minitest_controller_test_case.rb
@@ -32,7 +32,6 @@ class FakeMinitestControllerTestCase
     def attributes
       {
         "content" => FakeNokogiriAttr.new,
-        "data-analytics-dimension" => FakeNokogiriAttr.new,
       }
     end
   end


### PR DESCRIPTION
Universal Analytics has been replaced by Google Analytics 4. 

The custom dimension was a required field for UA, and is no longer needed by GA4 which processes events differently.
