### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 3.0.0
 
 * Drop support for Ruby 3.0. The minimum required Ruby version is now 3.1
 * **BREAKING CHANGE** No longer allow a GA custom dimension to be passed

--- a/lib/govuk_ab_testing/version.rb
+++ b/lib/govuk_ab_testing/version.rb
@@ -1,3 +1,3 @@
 module GovukAbTesting
-  VERSION = "2.4.3".freeze
+  VERSION = "3.0.0".freeze
 end


### PR DESCRIPTION
* Drop support for Ruby 3.0. The minimum required Ruby version is now 3.1
* **BREAKING CHANGE** No longer allow a GA custom dimension to be passed when creating a GovukAbTesting::AbTest object. The dimension parameter needs to be removed.